### PR TITLE
Add multilingual settings and model forms

### DIFF
--- a/app/[locale]/(dashboard)/models/[modelKey]/[itemId]/page.tsx
+++ b/app/[locale]/(dashboard)/models/[modelKey]/[itemId]/page.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useSession } from "next-auth/react";
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { adminApi } from "@/lib/api";
+import { FormInput } from "@/components/ui/form-input";
+import { FormButton } from "@/components/ui/form-button";
+import { useToast } from "@/hooks/use-toast";
+import { useTranslations } from "next-intl";
+
+export default function EditItemPage() {
+  const t = useTranslations("ModelListPage");
+  const params = useParams();
+  const router = useRouter();
+  const { data: session } = useSession();
+  const { toast } = useToast();
+  const modelKey = params.modelKey as string;
+  const itemId = params.itemId as string;
+
+  const [fields, setFields] = useState<{ name: string; label: string }[]>([]);
+  const [formData, setFormData] = useState<Record<string, any>>({});
+
+  useEffect(() => {
+    async function load() {
+      if (!session?.accessToken) return;
+      const configRes = await adminApi.getAdminConfig(session.accessToken);
+      if (!configRes.data) return;
+      const model = configRes.data.models[modelKey];
+      if (!model) return;
+      const cfg = await adminApi.getModelConfig(session.accessToken, model.config_url);
+      const f = Object.entries(cfg.data.fields || {}).map(([key, val]: any) => ({
+        name: key,
+        label: val.label || key,
+      }));
+      setFields(f);
+      const itemRes = await adminApi.getModelItem(session.accessToken, model.api_url, itemId);
+      if (itemRes.data) setFormData(itemRes.data);
+    }
+    load();
+  }, [session, modelKey, itemId]);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!session?.accessToken) return;
+    const configRes = await adminApi.getAdminConfig(session.accessToken);
+    const model = configRes.data.models[modelKey];
+    const resp = await adminApi.updateModelItem(session.accessToken, model.api_url, itemId, formData);
+    if (!resp.error) {
+      toast({ title: t("edit"), description: "OK" });
+      router.push(`/models/${modelKey}`);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-bold">{t("edit")}</h1>
+      <form onSubmit={submit} className="space-y-4">
+        {fields.map((f) => (
+          <FormInput
+            key={f.name}
+            label={f.label}
+            value={formData[f.name] || ""}
+            onChange={(e) => setFormData({ ...formData, [f.name]: e.target.value })}
+          />
+        ))}
+        <FormButton type="submit">{t("save")}</FormButton>
+      </form>
+    </div>
+  );
+}

--- a/app/[locale]/(dashboard)/models/[modelKey]/create/page.tsx
+++ b/app/[locale]/(dashboard)/models/[modelKey]/create/page.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useSession } from "next-auth/react";
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { adminApi } from "@/lib/api";
+import { FormInput } from "@/components/ui/form-input";
+import { FormButton } from "@/components/ui/form-button";
+import { useToast } from "@/hooks/use-toast";
+import { useTranslations } from "next-intl";
+
+export default function CreateItemPage() {
+  const t = useTranslations("ModelListPage");
+  const params = useParams();
+  const router = useRouter();
+  const { data: session } = useSession();
+  const { toast } = useToast();
+  const modelKey = params.modelKey as string;
+
+  const [fields, setFields] = useState<{ name: string; label: string }[]>([]);
+  const [formData, setFormData] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    async function load() {
+      if (!session?.accessToken) return;
+      const configRes = await adminApi.getAdminConfig(session.accessToken);
+      if (!configRes.data) return;
+      const model = configRes.data.models[modelKey];
+      if (!model) return;
+      const cfg = await adminApi.getModelConfig(session.accessToken, model.config_url);
+      const f = Object.entries(cfg.data.fields || {}).map(([key, val]: any) => ({
+        name: key,
+        label: val.label || key,
+      }));
+      setFields(f);
+    }
+    load();
+  }, [session, modelKey]);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!session?.accessToken) return;
+    const configRes = await adminApi.getAdminConfig(session.accessToken);
+    const model = configRes.data.models[modelKey];
+    const resp = await adminApi.createModelItem(session.accessToken, model.api_url, formData);
+    if (!resp.error) {
+      toast({ title: t("createNew"), description: "OK" });
+      router.push(`/models/${modelKey}`);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-bold">{t("createNew")}</h1>
+      <form onSubmit={submit} className="space-y-4">
+        {fields.map((f) => (
+          <FormInput
+            key={f.name}
+            label={f.label}
+            value={formData[f.name] || ""}
+            onChange={(e) => setFormData({ ...formData, [f.name]: e.target.value })}
+          />
+        ))}
+        <FormButton type="submit">{t("save")}</FormButton>
+      </form>
+    </div>
+  );
+}

--- a/app/[locale]/(dashboard)/models/[modelKey]/page.tsx
+++ b/app/[locale]/(dashboard)/models/[modelKey]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useSession } from "next-auth/react";
+import { useTranslations } from "next-intl";
 import { adminApi } from "@/lib/api";
 import { useToast } from "@/hooks/use-toast";
 import { Button } from "@/components/ui/button";
@@ -46,6 +47,7 @@ interface ModelItem {
 }
 
 export default function ModelListPage() {
+  const t = useTranslations("ModelListPage");
   const params = useParams();
   const router = useRouter();
   const { toast } = useToast();
@@ -200,7 +202,7 @@ export default function ModelListPage() {
         </div>
         <p className="text-destructive mb-4">{error}</p>
         <Button variant="outline" onClick={fetchData}>
-          Try Again
+          {t("tryAgain")}
         </Button>
       </div>
     );
@@ -222,7 +224,7 @@ export default function ModelListPage() {
           onClick={() => router.push(getModelUrl(modelKey, "create"))}
           disabled={isLoading}>
           <PlusIcon className="h-4 w-4 mr-2" />
-          Create New
+          {t("createNew")}
         </Button>
       </div>
 
@@ -232,16 +234,16 @@ export default function ModelListPage() {
             <thead className="bg-muted/50">
               <tr>
                 <th className="p-3 text-left font-medium text-sm text-muted-foreground">
-                  ID
+                {t("id")}
                 </th>
                 <th className="p-3 text-left font-medium text-sm text-muted-foreground">
-                  Name / Title
+                {t("name")}
                 </th>
                 <th className="p-3 text-left font-medium text-sm text-muted-foreground">
-                  Created At
+                {t("createdAt")}
                 </th>
                 <th className="p-3 text-left font-medium text-sm text-muted-foreground">
-                  Actions
+                {t("actions")}
                 </th>
               </tr>
             </thead>
@@ -251,7 +253,7 @@ export default function ModelListPage() {
                   <td
                     colSpan={4}
                     className="p-4 text-center text-muted-foreground">
-                    No items found
+                    {t("noItems")}
                   </td>
                 </tr>
               ) : (
@@ -279,22 +281,21 @@ export default function ModelListPage() {
                             router.push(getModelUrl(modelKey, item.id))
                           }>
                           <Pencil className="h-3.5 w-3.5 mr-1" />
-                          Edit
+                          {t("edit")}
                         </Button>
 
                         <AlertDialog>
                           <AlertDialogTrigger asChild>
                             <Button variant="destructive" size="sm">
                               <Trash2 className="h-3.5 w-3.5 mr-1" />
-                              Delete
+                              {t("delete")}
                             </Button>
                           </AlertDialogTrigger>
                           <AlertDialogContent>
                             <AlertDialogHeader>
-                              <AlertDialogTitle>Delete Item</AlertDialogTitle>
+                              <AlertDialogTitle>{t("deleteTitle")}</AlertDialogTitle>
                               <AlertDialogDescription>
-                                Are you sure you want to delete this item? This
-                                action cannot be undone.
+                                {t("deleteConfirm")}
                               </AlertDialogDescription>
                             </AlertDialogHeader>
                             <AlertDialogFooter>
@@ -305,7 +306,7 @@ export default function ModelListPage() {
                                   handleDelete();
                                 }}
                                 disabled={isDeleting}>
-                                {isDeleting ? "Deleting..." : "Delete"}
+                                {isDeleting ? "Deleting..." : t("delete")}
                               </AlertDialogAction>
                             </AlertDialogFooter>
                           </AlertDialogContent>

--- a/app/[locale]/(dashboard)/page.tsx
+++ b/app/[locale]/(dashboard)/page.tsx
@@ -2,6 +2,7 @@
 
 import { useSession } from "next-auth/react";
 import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
 import { motion, Variant } from "framer-motion";
 import { adminApi } from "@/lib/api";
 import { useToast } from "@/hooks/use-toast";
@@ -54,6 +55,7 @@ const fadeInUpVariants = {
 
 export default function DashboardPage() {
   const { data: session, status } = useSession();
+  const t = useTranslations("DashboardPage");
   const router = useRouter();
   const [adminConfig, setAdminConfig] = useState<AdminConfig | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -145,10 +147,8 @@ export default function DashboardPage() {
   return (
     <div>
       <div className="mb-8">
-        <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
-        <p className="text-muted-foreground mt-2">
-          Manage your application data and settings.
-        </p>
+        <h1 className="text-3xl font-bold tracking-tight">{t("title")}</h1>
+        <p className="text-muted-foreground mt-2">{t("description")}</p>
       </div>
 
       <div className="space-y-8">

--- a/app/[locale]/(dashboard)/settings/page.tsx
+++ b/app/[locale]/(dashboard)/settings/page.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { FormInput } from "@/components/ui/form-input";
+import { FormButton } from "@/components/ui/form-button";
+import { dashboardConfig } from "@/lib/config";
+import { useToast } from "@/hooks/use-toast";
+
+export default function SettingsPage() {
+  const t = useTranslations("SettingsPage");
+  const { toast } = useToast();
+
+  const [siteName, setSiteName] = useState(dashboardConfig.name);
+  const [logoUrl, setLogoUrl] = useState(dashboardConfig.logoUrl);
+  const [navbarStyle, setNavbarStyle] = useState("modern");
+  const [otpEnabled, setOtpEnabled] = useState(false);
+
+  useEffect(() => {
+    const storedName = localStorage.getItem("siteName");
+    if (storedName) setSiteName(storedName);
+    const storedLogo = localStorage.getItem("logoUrl");
+    if (storedLogo) setLogoUrl(storedLogo);
+    const style = localStorage.getItem("navbarStyle");
+    if (style) setNavbarStyle(style);
+    const otp = localStorage.getItem("otpEnabled");
+    if (otp === "true") setOtpEnabled(true);
+  }, []);
+
+  const handleSave = (e: React.FormEvent) => {
+    e.preventDefault();
+    localStorage.setItem("siteName", siteName);
+    localStorage.setItem("logoUrl", logoUrl);
+    localStorage.setItem("navbarStyle", navbarStyle);
+    localStorage.setItem("otpEnabled", String(otpEnabled));
+    toast({ title: t("title"), description: t("save") });
+    window.location.reload();
+  };
+
+  return (
+    <div className="space-y-8">
+      <h1 className="text-2xl font-bold">{t("title")}</h1>
+      <form className="space-y-4" onSubmit={handleSave}>
+        <div>
+          <h2 className="font-semibold mb-2">{t("general")}</h2>
+          <FormInput
+            label={t("siteName")}
+            value={siteName}
+            onChange={(e) => setSiteName(e.target.value)}
+          />
+          <FormInput
+            label={t("logo")}
+            value={logoUrl}
+            onChange={(e) => setLogoUrl(e.target.value)}
+          />
+          <div className="mt-2">
+            <label className="form-label" htmlFor="navbarStyle">
+              {t("navbarStyle")}
+            </label>
+            <select
+              id="navbarStyle"
+              className="form-input"
+              value={navbarStyle}
+              onChange={(e) => setNavbarStyle(e.target.value)}
+            >
+              <option value="minimalistic">minimalistic</option>
+              <option value="modern">modern</option>
+              <option value="simple">simple</option>
+            </select>
+          </div>
+        </div>
+        <div>
+          <h2 className="font-semibold mb-2">{t("otp")}</h2>
+          <label className="flex items-center space-x-2">
+            <input
+              type="checkbox"
+              checked={otpEnabled}
+              onChange={(e) => setOtpEnabled(e.target.checked)}
+            />
+            <span>{t("otp")}</span>
+          </label>
+        </div>
+        <div>
+          <h2 className="font-semibold mb-2">{t("password")}</h2>
+          <FormInput label="Current Password" type="password" required />
+          <FormInput label="New Password" type="password" required />
+        </div>
+        <FormButton type="submit">{t("save")}</FormButton>
+      </form>
+    </div>
+  );
+}

--- a/components/language-switcher.tsx
+++ b/components/language-switcher.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { usePathname, useRouter } from "@/i18n/routing/navigation";
+
+const locales = ["en", "de", "fr"] as const;
+
+export function LanguageSwitcher() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const currentLocale = router.locale;
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const locale = e.target.value;
+    router.push(pathname, { locale });
+  };
+
+  return (
+    <select
+      onChange={handleChange}
+      value={currentLocale}
+      className="border rounded px-2 py-1 text-sm bg-background"
+    >
+      {locales.map((loc) => (
+        <option key={loc} value={loc}>
+          {loc.toUpperCase()}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/components/layout/dashboard-layout.tsx
+++ b/components/layout/dashboard-layout.tsx
@@ -20,6 +20,7 @@ import { DynamicIcon } from "@/components/ui/dynamic-icon";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useToast } from "@/hooks/use-toast";
+import { LanguageSwitcher } from "@/components/language-switcher";
 
 // Sidebar animation variants
 const sidebarVariants: Variants = {
@@ -69,6 +70,11 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
   const [theme, setTheme] = useState<"light" | "dark">("light");
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [isMobileView, setIsMobileView] = useState(false);
+  const [siteName, setSiteName] = useState(dashboardConfig.name);
+  const [logoUrl, setLogoUrl] = useState(dashboardConfig.logoUrl);
+  const [navbarStyle, setNavbarStyle] = useState(
+    typeof window !== "undefined" ? localStorage.getItem("navbarStyle") || "modern" : "modern"
+  );
 
   // Toggle between light and dark mode
   const toggleTheme = () => {
@@ -120,6 +126,13 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
       document.documentElement.classList.add("dark");
     }
 
+    const storedName = localStorage.getItem("siteName");
+    if (storedName) setSiteName(storedName);
+    const storedLogo = localStorage.getItem("logoUrl");
+    if (storedLogo) setLogoUrl(storedLogo);
+    const storedStyle = localStorage.getItem("navbarStyle");
+    if (storedStyle) setNavbarStyle(storedStyle);
+
     // Sidebar state initialization
     const savedSidebarState = localStorage.getItem("sidebarCollapsed");
     if (savedSidebarState === "true") {
@@ -146,6 +159,7 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
         variants={sidebarVariants}
         initial={false}
         animate={isCollapsed ? "collapsed" : "expanded"}
+        data-style={navbarStyle}
         className={cn(
           "bg-sidebar text-sidebar-foreground border-r border-sidebar-border hidden md:flex flex-col z-30",
           isCollapsed ? "items-center" : "items-start"
@@ -158,8 +172,8 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
             animate={isCollapsed ? "collapsed" : "expanded"}
             className="overflow-hidden flex items-center">
             <img
-              src={dashboardConfig.logoUrl}
-              alt={dashboardConfig.name}
+              src={logoUrl}
+              alt={siteName}
               className="h-8 w-8"
             />
             <motion.span
@@ -167,7 +181,7 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
               initial={false}
               animate={isCollapsed ? "collapsed" : "expanded"}
               className="ml-3 font-semibold text-lg">
-              {dashboardConfig.name}
+              {siteName}
             </motion.span>
           </motion.div>
           <Button
@@ -217,6 +231,7 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
         {/* Sidebar Footer */}
         <div className="p-4 border-t border-sidebar-border w-full">
           <div className="flex items-center justify-between">
+            <LanguageSwitcher />
             <Button
               variant="ghost"
               size="icon"
@@ -257,12 +272,12 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
               <SheetContent side="left" className="p-0 bg-sidebar">
                 <div className="h-16 flex items-center px-4 border-b border-sidebar-border">
                   <img
-                    src={dashboardConfig.logoUrl}
-                    alt={dashboardConfig.name}
+                    src={logoUrl}
+                    alt={siteName}
                     className="h-8 w-8"
                   />
                   <span className="ml-3 font-semibold text-lg text-sidebar-foreground">
-                    {dashboardConfig.name}
+                    {siteName}
                   </span>
                 </div>
                 <ScrollArea className="h-[calc(100vh-8rem)]">
@@ -288,6 +303,7 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
                 </ScrollArea>
                 <div className="absolute bottom-0 left-0 right-0 p-4 border-t border-sidebar-border">
                   <div className="flex items-center justify-between">
+                    <LanguageSwitcher />
                     <Button
                       variant="ghost"
                       size="icon"
@@ -311,12 +327,12 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
               </SheetContent>
             </Sheet>
             <img
-              src={dashboardConfig.logoUrl}
-              alt={dashboardConfig.name}
+              src={logoUrl}
+              alt={siteName}
               className="h-8 w-8 ml-3"
             />
             <span className="ml-3 font-semibold text-lg">
-              {dashboardConfig.name}
+              {siteName}
             </span>
           </div>
           <Button

--- a/messages/de.json
+++ b/messages/de.json
@@ -4,5 +4,33 @@
     "usernameLabel": "Benutzername",
     "passwordLabel": "Passwort",
     "signInButton": "Anmelden"
+  },
+  "DashboardPage": {
+    "title": "Dashboard",
+    "description": "Verwalten Sie Ihre Anwendungsdaten und Einstellungen."
+  },
+  "ModelListPage": {
+    "createNew": "Neu erstellen",
+    "id": "ID",
+    "name": "Name / Titel",
+    "createdAt": "Erstellt am",
+    "actions": "Aktionen",
+    "noItems": "Keine Einträge gefunden",
+    "edit": "Bearbeiten",
+    "delete": "Löschen",
+    "deleteTitle": "Eintrag löschen",
+    "deleteConfirm": "Möchten Sie diesen Eintrag wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.",
+    "tryAgain": "Erneut versuchen",
+    "save": "Speichern"
+  },
+  "SettingsPage": {
+    "title": "Einstellungen",
+    "general": "Allgemein",
+    "siteName": "Seitenname",
+    "logo": "Logo-URL",
+    "navbarStyle": "Navbar-Stil",
+    "otp": "Zwei-Faktor-Authentifizierung aktivieren",
+    "password": "Passwort ändern",
+    "save": "Speichern"
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -4,5 +4,33 @@
     "usernameLabel": "Username",
     "passwordLabel": "Password",
     "signInButton": "Sign In"
+  },
+  "DashboardPage": {
+    "title": "Dashboard",
+    "description": "Manage your application data and settings."
+  },
+  "ModelListPage": {
+    "createNew": "Create New",
+    "id": "ID",
+    "name": "Name / Title",
+    "createdAt": "Created At",
+    "actions": "Actions",
+    "noItems": "No items found",
+    "edit": "Edit",
+    "delete": "Delete",
+    "deleteTitle": "Delete Item",
+    "deleteConfirm": "Are you sure you want to delete this item? This action cannot be undone.",
+    "tryAgain": "Try Again",
+    "save": "Save"
+  },
+  "SettingsPage": {
+    "title": "Settings",
+    "general": "General",
+    "siteName": "Site Name",
+    "logo": "Logo URL",
+    "navbarStyle": "Navbar Style",
+    "otp": "Enable Two-factor Authentication",
+    "password": "Change Password",
+    "save": "Save Changes"
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -4,5 +4,33 @@
     "usernameLabel": "Nom d'utilisateur",
     "passwordLabel": "Mot de passe",
     "signInButton": "Se connecter"
+  },
+  "DashboardPage": {
+    "title": "Tableau de bord",
+    "description": "Gérez les données et paramètres de votre application."
+  },
+  "ModelListPage": {
+    "createNew": "Créer",
+    "id": "ID",
+    "name": "Nom / Titre",
+    "createdAt": "Créé le",
+    "actions": "Actions",
+    "noItems": "Aucun élément trouvé",
+    "edit": "Modifier",
+    "delete": "Supprimer",
+    "deleteTitle": "Supprimer l'élément",
+    "deleteConfirm": "Êtes-vous sûr de vouloir supprimer cet élément ? Cette action est irréversible.",
+    "tryAgain": "Réessayer",
+    "save": "Enregistrer"
+  },
+  "SettingsPage": {
+    "title": "Paramètres",
+    "general": "Général",
+    "siteName": "Nom du site",
+    "logo": "URL du logo",
+    "navbarStyle": "Style de la barre",
+    "otp": "Activer l'authentification à deux facteurs",
+    "password": "Changer le mot de passe",
+    "save": "Enregistrer"
   }
 }


### PR DESCRIPTION
## Summary
- add language switcher component and hook it into dashboard layout
- localize dashboard page, model list page and add translations
- provide settings page to change site name, logo, OTP and navbar style
- support editing and creating model items
- load custom site config from localStorage in dashboard layout

## Testing
- `npm run lint` *(fails: asks for configuration)*
